### PR TITLE
Add upcoming races section to Running page

### DIFF
--- a/src/running/RunningSection.vue
+++ b/src/running/RunningSection.vue
@@ -4,6 +4,22 @@
       title="Running"
       icon="running"
       subtext="I got into running while the pandemic had the gyms closed. Now I'd like to make a habit of running a different marathon every few years, with some other races every now and then. I ran my first official marathon in the Spring of 2022, which is listed below. Hopefully I'll add more to this list in the coming years." />
+    <!-- Upcoming Races -->
+    <div class="upcoming-races">
+      <h3>Upcoming Races</h3>
+      <ul>
+        <li>
+          <a
+            href="https://www.jecoursqc.com/en/beneva-quebec-city-marathon-presented-by-montellier/races/#/21-1k-shop-sante-presented-by-wknd-91-9"
+            target="_blank"
+            rel="noopener noreferrer">
+            Quebec City Half Marathon
+          </a>
+          &mdash; Beneva Quebec City Marathon, Summer 2026
+        </li>
+      </ul>
+    </div>
+
     <div class="section-body">
       <RunningCard
         v-for="race in orderedRaces"
@@ -45,6 +61,44 @@ export default defineComponent({
 #races {
   display: flex;
   flex-direction: column;
+
+  .upcoming-races {
+    margin: 1.5rem 0;
+    padding: 1.5rem;
+    background: rgba(51, 129, 219, 0.05);
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    box-sizing: border-box;
+
+    h3 {
+      margin: 0 0 0.75rem 0;
+      color: $primary;
+      font-size: 1.3rem;
+      font-weight: 600;
+    }
+
+    ul {
+      margin: 0;
+      padding-left: 1.25rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.6rem;
+    }
+
+    li {
+      color: $fontColor;
+      line-height: 1.5;
+    }
+
+    a {
+      color: $primary;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
 
   .section-body {
     display: flex;


### PR DESCRIPTION
## Summary
Added a new "Upcoming Races" section to the Running page to highlight future race participation before the list of completed races.

## Changes
- Added a new "Upcoming Races" section above the existing race cards in `RunningSection.vue`
- Included the Quebec City Half Marathon (Summer 2026) as the first upcoming race with a link to the official event page
- Styled the upcoming races section with:
  - Light blue background (`rgba(51, 129, 219, 0.05)`) to distinguish it from completed races
  - Subtle box shadow for depth
  - Consistent typography and spacing matching the site's design system
  - Responsive link styling with hover underline effect

## Implementation Details
- The upcoming races section uses a simple unordered list structure for easy maintenance and future additions
- Links open in a new tab with `target="_blank"` and `rel="noopener noreferrer"` for security
- Styling leverages existing SCSS variables (`$primary`, `$fontColor`) for consistency with the site's color scheme
- The section is positioned prominently above the race history to draw attention to future events

https://claude.ai/code/session_01JkzymRQGdDExWgsWLT72V6